### PR TITLE
Removing duplicate rip_urls

### DIFF
--- a/assets/travelling.js
+++ b/assets/travelling.js
@@ -510,7 +510,7 @@ function travelling() {
     }
   }
 
-
+  url = [... new Set([rip_url,].concat(url))].slice(1);
   var ints = Math.floor(Math.random() * url.length);
   window.location = url[ints];
 }


### PR DESCRIPTION
如 #935 沟通, 删除过多的rip_url以降低多次rip的概率, 但是如果有失效链接的话, 则只保留一个rip_url 