### PR TITLE
网站地址变更 #639 cpen.top => blog.cpen.top

### DIFF
--- a/assets/travelling.js
+++ b/assets/travelling.js
@@ -644,7 +644,7 @@ function travelling() {
   urls[636] = "yingqing.cf";
   urls[637] = "bolg.wuenci.wang";
   urls[638] = "www.zh996.com";
-  urls[639] = "cpen.top";
+  urls[639] = "blog.cpen.top";
   urls[640] = "www.luodeb.top";
   urls[641] = "blog.mrzefr.cn";
   urls[642] = "kqh.me";


### PR DESCRIPTION
网站地址变更
#639 cpen.top => blog.cpen.top