### PR TITLE
i18n: fix some links, typo and change explode to crash

### DIFF
--- a/en_US/docs/qa.md
+++ b/en_US/docs/qa.md
@@ -59,7 +59,7 @@ A:
 The patrol backend has two stages of patrols\
 The first stage is for the backend patrol to quickly detect all sites (about 30 minutes)\
 In the second stage, the backend patrol will use a browser to recheck the abnormal sites detected in the first stage (which may take longer)\
-If the backend patrol server does not explode, it usually starts patrolling around 4 am every day.
+If the backend patrol server does not crash, it usually starts patrolling around 4 am every day.
 
 ## Q: What are the characteristics of the patrol?
 

--- a/en_US/docs/thanks.md
+++ b/en_US/docs/thanks.md
@@ -50,4 +50,4 @@ Here we regularly list the individuals or teams sponsors.
 
 ## Heading to the early member list
 
-Kaiwang(Travellings) thanks the members who joined Kaiwang in version 1.2.3 and before, although most of them have quit Kaiwang for various reasons or been deleted by Kaiwang patrol. This totals 145 sites. Due to space limitations, you can read <https://github.com/travellings-link/travellings/blob/a439f99eb100a454e419eb65182c980e848a9854/README.md#%E7%BD%91%E7%AB%99%E6%94%B6 %E5%BD%95> to see them.
+Kaiwang(Travellings) thanks the members who joined Kaiwang in version 1.2.3 and before, although most of them have quit Kaiwang for various reasons or been deleted by Kaiwang patrol. This totals 145 sites. Due to space limitations, you can read [here](https://github.com/travellings-link/travellings/blob/a439f99eb100a454e419eb65182c980e848a9854/README.md#%E7%BD%91%E7%AB%99%E6%94%B6%E5%BD%95) to see them.

--- a/en_US/docs/thanks.md
+++ b/en_US/docs/thanks.md
@@ -4,7 +4,7 @@ On this page we store those people who need to express our gratitude on behalf o
 
 ## Sponsor list
 
-Here we regularly list the individuals or teams we sponsor to travel to.
+Here we regularly list the individuals or teams sponsors.
 
 | **Time**   | **Sponsor**                          | **Amount** | **Use**                                |
 | ---------- | -------------------------------- | -------- | --------------------------------------- |
@@ -50,4 +50,4 @@ Here we regularly list the individuals or teams we sponsor to travel to.
 
 ## Heading to the early member list
 
-Kaiwei thanks the members who joined Kaiwei in version 1.2.3 and before, although most of them have quit Kaiwei for various reasons or been deleted by Kaiwei patrol. This totals 145 sites. Due to space limitations, you can read [here](https://github.com/travellings-link/travellings/blob/a439f99eb100a454e419eb65182c980e848a9854/README.md#%E7%BD%91%E7%AB%99%E6%94%B6 %E5%BD%95) see them.
+Kaiwang(Travellings) thanks the members who joined Kaiwang in version 1.2.3 and before, although most of them have quit Kaiwang for various reasons or been deleted by Kaiwang patrol. This totals 145 sites. Due to space limitations, you can read [here](https://github.com/travellings-link/travellings/blob/a439f99eb100a454e419eb65182c980e848a9854/README.md#%E7%BD%91%E7%AB%99%E6%94%B6 %E5%BD%95) to see them.

--- a/en_US/docs/thanks.md
+++ b/en_US/docs/thanks.md
@@ -50,4 +50,4 @@ Here we regularly list the individuals or teams sponsors.
 
 ## Heading to the early member list
 
-Kaiwang(Travellings) thanks the members who joined Kaiwang in version 1.2.3 and before, although most of them have quit Kaiwang for various reasons or been deleted by Kaiwang patrol. This totals 145 sites. Due to space limitations, you can read [here](https://github.com/travellings-link/travellings/blob/a439f99eb100a454e419eb65182c980e848a9854/README.md#%E7%BD%91%E7%AB%99%E6%94%B6 %E5%BD%95) to see them.
+Kaiwang(Travellings) thanks the members who joined Kaiwang in version 1.2.3 and before, although most of them have quit Kaiwang for various reasons or been deleted by Kaiwang patrol. This totals 145 sites. Due to space limitations, you can read <https://github.com/travellings-link/travellings/blob/a439f99eb100a454e419eb65182c980e848a9854/README.md#%E7%BD%91%E7%AB%99%E6%94%B6 %E5%BD%95> to see them.

--- a/en_US/docs/toyou.md
+++ b/en_US/docs/toyou.md
@@ -6,7 +6,7 @@ If you wish to join the maintenance team, you can visit the [blog](https://www.t
 
 The main site of Travellings is now built with VitePress.
 
-- `public` folder stores the static file, which will be placed in the root folder of the site. The most important jump pages are also included. Jump pages to the most important ones are also included. If you want to make a new jump page, please check out [Participation Project](https://www.travellings.cn/docs/join#%E5%8F%82%E4%B8%8E%E9%A1%B9% E7%9B%AE)
+- `public` folder stores the static file, which will be placed in the root folder of the site. The most important jump pages are also included. Jump pages to the most important ones are also included. If you want to make a new jump page, please check out [Participation Project](https://www.travellings.cn/docs/join#%E5%8F%82%E4%B8%8E%E9%A1%B9%E7%9B%AE)
 - `announcements` folder stores announcements (in Markdown).
 - `blog` folder stores our blog posts (in Markdown).
 - `docs` folder stores documents (in Markdown).


### PR DESCRIPTION
What happened?
The page https://www.travellings.cn/en_US/docs/toyou and https://www.travellings.cn/en_US/docs/thanks doesn't appear right.
And the translation of "baozha" is inappropriate. And I also fixed some typo problem.

I noticed that it is strange zh-TW pages doesn't have the similar problem. So I request a review.