### PR TITLE
Update pr-translate-zh_tw.yml to fix CI Error

### DIFF
--- a/.github/workflows/pr-translate-zh_tw.yml
+++ b/.github/workflows/pr-translate-zh_tw.yml
@@ -1,5 +1,8 @@
 name: Translate Docs
 
+permissions:
+  pull-requests: write
+
 on:
   pull_request:
     types: [opened, synchronize]


### PR DESCRIPTION
为CI添加PR的write权限，解决Translate Check会在comment on PR过程报Resource not accessible by integration错误