### PR TITLE
perf(shuttle): 对现有跳转页面 Travellings Shuttle System (.\go-start.html) 的重构和更改。

### DIFF
--- a/public/go-start.html
+++ b/public/go-start.html
@@ -6,14 +6,18 @@
                                  /___/     
 
 Travellings v.3.0.0
-Travellings Shuttle System (c) Travellings-link Project. All rights reserved.
+Travellings Shuttle System v.0.2.3.9
+Made by AdminCmd(https://admincmd.xyz)#1355 with love.
 https://www.travellings.cn/
 https://github.com/travellings-link/travellings
 
 -->
-<!-- Made by 2026 AdminCmd(https://admincmd.xyz/)(https://github.com/admincmd-a) with Love. -->
+<!-- Made by 2026 AdminCmd(https://admincmd.xyz/)(https://github.com/admincmd-a) Travellings#1355 with Love. -->
 <!-- 鄙人不才，实现了在学校的胡思乱想，此代码是在几天晚自习回家后的晚上内赶出来的，运行效率和效果不尽人意(￣▽￣)" -->
-<!-- 完工日期：2026-03-25 -->
+<!-- 2026-03-25 第一次完成 -->
+<!-- 2026-08-12 15:37:51 UTC+08:00 第一次重构完成 -->
+<!-- BUG 反馈：请前往 admincmd.xyz 或发送邮件至 admi_ncmd@outlook.com -->
+
 
 <!-- 一个仿旧式 DOS 计算机的跳转页面，提供内嵌字体和一个阉割版的 CONHOST 控制台模拟器 -->
 <!-- 按键定义：
@@ -51,7 +55,7 @@ https://github.com/travellings-link/travellings
             --color-d: #b4009e;
             --color-e: #f9f1a5;
             --color-f: #f2f2f2;
-            --VGA-font: 'VGA','宋体' ,'Segoe UI', 'Lucida Grande', 'Helvetica Neue', 'Arial', sans-serif;
+            --VGA-font: 'VGA';
         }
 
         ::selection {
@@ -65,18 +69,36 @@ https://github.com/travellings-link/travellings
         }
 
         body {
-            font-size: 120% !important;
-            font-family: var(--VGA-font);
+            font-size: 100% !important;
+            font-family: var(--VGA-font),'宋体' ,'Segoe UI', 'Lucida Grande', 'Helvetica Neue', 'Arial', sans-serif;
             background-color: var(--color-0);
             color: var(--color-7);
             overflow: hidden;
             white-space: nowrap;
         }
 
+        span.cell {
+            display: inline-block;
+            position: relative; /* 定位，只是让它不是静态而已 */
+            line-height: 1;          /* 行高等于1倍字号，消除多余的垂直空白 */
+            vertical-align: top;     /* 顶部对齐，消除基线带来的下降空隙 */
+        }
 
         @font-face {
             font-family: 'VGA';
             src: url("data:font/ttf;base64,d09GMgABAAAAABT8AAsAAAAAYUAAABSqAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAABmAAiSARCAqBmCTtKguECAABNgIkA4gMBCAFhj8HiwYb/EgHxjErcTsQQtXLO4qauShtjKgcDTf7/z8lORlDwGLTaVX9PzmC0tTNA6aiwKSgWKYwdUxziaTjVEG99biubL61t31KBMIBp1WRKYUxjTzjRR8ppsjg8yNf31YBC3s/Rojp3T7qa/4ZhYUXfmigj5aJVSgVONSkMnngB/NYoQKpDCs3eLOess7vdfHqyril93Q0/JXtnYyQIbd9yO7t7czuD9iBP67OKFOe6sDy0YPbxEJx2xwfJpEWHvIP5nUpLi9UGA86dXa3iQDCf/6hpunb+HQj6FJZqTDpgoahTB8AFAYDvRS0a69pEk/K5BUDsu9tbQCRg3OKGZDQOdhQ4YiKQKdtCoOEB8bfmBl9aMXWAvdZDK07RkD8w7/T0CEP8zE/hzgUIxJxZDAlQ2k7FIQ5hSpZiBLr3nnNb99Ov/nBUwqb7ztLku2ARhNfXr9/lwpL7QLngJKgMJkN7HnQ/v8D4OnGtuxtAEvc/d9apa2+yfTMHXeAVG5ViJ5HFbVRkfERqutXVdcUTe/2LHYtMNVhz4TZ3YskTyjjTuX5CA2sRJwBEjpOk7A61sX/WtbsNDkJN2RJeXJ5HEoyO92vit0l5dkjxLCvfy/X0zdHSiqkZLE4pAnZ4zw4hKXYVjNkGypOnTUuy1Aq+rzHJ6lfw1xD0mt90pnUr36IlGLckA2uuEbccowfA5T1VSwcRLn0vkVi5Pb/gukcjMc5iQBCAAD4QgS4/gAAALQ+yMcLORbAv0wthuA5YPq+APVtAOCTAFAAFIA8GQBILhQMAHkaCQTI5IsHeX9XJSrVa9Glx4gxc5Zt2vfeF3/8j09CClKcstSlKa3pTC8dpMP88x/zfWDJTtqlKFK2SAtSfCp6KkaqRDXKHEjqqVs9gAU8EIEKcCDACX7qvgQSSiQJ5FJJPe10Mqg+oU5lzWON55TF7vIfwJerSLlaTdr1GER253ZwiI/KN95wwIs9R0ZFMXfcEn7hxU3Fnrfq4aHT9/9G/u/19nS1tzY31dWWFeVmZ2VmpAn8FfBDbi6cOXZgz27fHWy77cjubDsV2I7YttoOtr2t/1b5VkZfq0unBrWqlCuRK028CK6aaspyCUMAd8dtV2iSq6PWWkovtZQSx6D/Q73SX7IhAh7BHcjgtykGBFRI/wuCIIQgDBGIQgzikIAkncFksTlcHl8gFIklUplcoVQBIAQjKIarNVqd3mAkTGaL1WZ3OF1ujxeDxeEJRBKZQqXRGUwWm8Pl8QVCkVgilckVSsoATlY2tnb2Ds5OLvwA/gIFCxIiVLgwESJFiREtVhwgSaJkKQBzNXUtT9aOeulC89uw8NfK0HD9Q6QAYGICECCBo6qulzRNAFNTAF31kuIBqdrbAXU+Xea/AIChAEB4AHkDpB7IPgAAqJEAAAABAQGFEAgIhuguesgmfZdRT25keu1ou7zdEuWQ/NbxzZrDBeAWJNzDeeBIuS3IFJOegoSqZKjSqWzJZ7dxnzghNGbWVtsmp7UK1nuWaOARHsttbPAsLh6wkBMVS75qLbiXFqsMsTpD3mR6DBo+9PB49S9GZpvxmi352D1WkgMENtjXuFEyH4SLh1C8TyTuSjs6amkR8ImuHa7audUqGIVzcVbLk4Oep4SLIzebUi2SvMYohs9vrneb/9EyL0vuCYfjclhsP68KgTHhGiBnUW+tUHAVIglSMmyKXq6HjhNdlyKrg4nmxATpbVoNAUBcNEZJVKGQRHuoj31+t9brPAvsJI6gkrHek1ljcsyG7z+iHUHmnFYMGyzUngh0w5wt53rEaGCEAgABVmGraNKUhvw46YMfAlmCX6lBQpaO882KVn+qiazjywxs3p+JtkueoBTYbXWWmbfoucGuYK9iL22veDGSN3k343MKdVe/qysMSpYCjxQC0DUSrko5WlE69aiUn7p4idi5q2cu63tR1rj9h80AKeCoKNGkIQ+8ziirINrJukYtcaf4oJAEFq3vkkoBmEYuq2eFUtEvILEmFHJKKD240upz0L6iI5a7q4grU+9T77V7n8gH9R5aBeeibBuKqrOjAFAfK6H1DpgFptKATPSRuO4iKnnORmwj4wGkiU2SoiHzhzIyuPpOTB35DAmNkNla2eFtxgory2/Vewo7qBdVlUJW/nVEAJ1kcLHIRk+h3VhzTxVoLBHQ8vYAxaAb3Wvkp+JUcP+Y7khR1hKsyBgmQlRa5SvoNRsGGRoZPKwyW0byohAQUGmVf4yZEPehRzMf4KJEzN7t2Iuid8XiNaAMeJ1EF36py/REd+eDTuuTNOZSaKvIrCTsOAZ7bUC+oSuzrswsnLEoDumv4ucHbKQ6D2WZsUADFweIaVfPOoSFNiuFSruxOYqLD7clIBhdxDJHxVmiL9mcDFTfNww5BYKN7l4Hr5rYGEMTG3aUVOQKHvOgQdhJLlArHpJ0Q007O1qwE2SVljaBJWVDo/6VQCFqdhq1NQYTzwdpEII8y5uSxIiyVoVs4P2DFZYkQ8I7SuXn4VoljjLJd/UTBJbuoj60zj1QZDWBzpo2GUtdJI4usMPU0EqzmgggCxZSjB1jYVwWr8o5i5mEOaobBKxZIr8SduXZ6cHWJFqJMEoayG+DBdku5lyAqbgHliV17V2Yb2zrEC/SIA3TS2hbXgoCGDuZeVul7DUCznFdCmBHo3h2axDGso09y1i5MlAuNswKKiPu4CIOgTyoww9gKTohBWuhaY1yohH/YiXRiEKgqU/u5MDAAkaNAusM92Uw8azCjCVV4MLVoCCjBoJeqIG6LAS/DKrdtOJ6CCBbArPehoChQJHaahUfBpKjEgqDxY3FVZKzMaYFfeLCQUo0QQStSrKuLVnjz8Xzljou4uBjsrc0JQ/6P8wJIK4JBqGYnBIu0BjBIcGXb5Blz4qILwC5SkYpWjkphqwFOBJc/nLPokZnFlQTuJQZj/IimVtNPehYpUV0hqLiZtWGn7Kv+soV/SmNOpaZ9iQoavYb/F48XxfK9h2/6L3bK/FluwRw21pOIJC0FIdkLr9PJMSzoGVX5Scl5WQEc8Ex5VwwZ0sIWYqw+DIgsYKHSZo0ByCLHds2k9iDdE0qalWSVsVdjqK89zoVvIRhyXamDUv0zSgqyIVCUhcGWqYlMF4VS8+EtLok8Vh9hKtDF1o4vm7aaM6KwXIt+kwMJCvGVOcoc0q3CQ8qXkQUmvNzeYlYJ8/VXVXMrirFrVnv4gOkjhDnUo6JSBZt9K1mootzYZUovRNPSoQgKwVCQjhe2cmdrOyd7IEOYsNhYeFQrBgeVkBaxcbOHRYfjlqyI7ykGIXVBSxJCb31k44cwzoryRlRVoQdkuwnrS5JLzjgokTYJDuUpFhZXVAX3ipFCvY0ZEKipbjITWk8N7oCSw8rmsCiB8VKLFSJGAlayL5Mkgh0syP5CK1LkxNIAoWFQyWyPkkMIxhRKQNRRKRYQGuT/HdwwdGBARUxUSIbXhsuJFPCnisjnlEcMUAAfwgEaNL1rDqQ7+QhJUC0jsJ1CRlYH3easyeZ0reFTXNhL6pfe8tq9YVLwv6vNYc9cE41GJgLKgMwgiOXp2lzSgkGQKf+YoSwFN8PTS1nLrON/oLvlCr/AQ2S7M6wu+6AmQz1qInnArIPLVnSBVP0g+bvkirrxj6lA4KQbLRiebHoo0vLvdZOn1SNLNceqo801mAtC4WJW8OyNVubSTofeFZiSUrrdFuPa1AoCfVcLb0eVs4uRRse142PfUByj1XF2u65Z1OlaAFiP3akA13Oe7GR4AArWxM3wIjFjm1/zoDzVol1zrYfiStf5A/qkhsagKGCUZqxs0JHtQ0eRl5j0PF77pl7qOzXSYOcQFRblaNBWZWBloVIiDPpWn2gudOKG2UanOEZaiixxRW1QgAGtoUtbAl2ikMtYPeb17hJfOSpKvACINgJnWSAyQQy3NwG+hFCcowsNMfpwDrDXrPsZug3x7qZbVDnx3gry3T/Y1p0L2fR1vpSP2cW1+ijXKrKX5z0J/T/4SrUWRS8MeZQl8utjSas6xQCn68txCMKludBnTl6XkImuYZHhHXNpEiu0TklhGN7wcu/meVCnRc+aqjXxMEPeWrzk1yrOE/MGP29aEYLec7+EiTZpCjVi9jlRqP5XR1jo7nPPJkd/xN/HJ+dYEnYn0Iql56uVHu0+lQGkR2gUQbHRbgfCVbSVKeMKYyTwFQRjdK5M2KEyCtjVTupqwYTBYrZjgK9AedfYL9rMdk3RT9539BKGKoHiJg6cy2owXJBUaR/FkoXb7SMdSsfUT8Xwqwqt9c7pQnjZlpVarUXRxvYU3PZ9YCK4J6KzHGS/zyy05yXL5jUu816yT3NVLnJj0Ly6lIVbjvl8gg3R1d7d8ZtfXV9O8KDTOCG9VhnAbHyEGkx3Il3hfZCAXGGaubDwjGYwgdjOUCtXB5pmDJBF9ODZ2KXrUiGr2qMQtVBuSD8dcq3Jg5++RVNUH+rggGvvmbJl6Zsf2IqYqf7Vbi+KqrLRixkTD5dFdjvBGJmlSU62sCDb8S5kKA/8Ihn1HAcLdYBAdg8rliwx1sHpYQFHZO8Y/DOuXo9gnBgLmuBYyIB0nfG5ytu4NL4QzYXiCPIk85wzQ6elVP0K9DuFDGAbgW0xX11KezCyNOObM9wjWkKx1Vl1pTDt48KrzTJd00Mxn5scO5MbuB9Slm3MbWfjGNoTqhPOmipatX7llUaPgBPYV3Ct2cuypwjIiVvTHiWEIb2jwSoOAT/IMDWAq7yObysRv24lwhyaHLM9bYGgOJKV+3Dg2jADywjhyzhqYpJWqsh4+fNus6QOXJIdcpCgD6EUuRyakXP429IysY8nnGHe4DsV70bomia0qzzlq3Y6sVwYsVYghup0WUvKi7nnpVRNfw7dwKhCgiqsXptoOjslyWV2jtLU7BaH9rSMGj6pfiNoOPld74HbUyDxC/y1PsvjR340xU55aAjBki0ogCox6/v+LIqVNtULToNoDfUPYxc7Z7j4jnjfEKnHCk/eV/nllWP/Jo+NlLAL5CbSNTWg7GURnxa1Sq6Z0txx+ne7XB0OisT0wgDeAVw0BLoMxPe1fm3LX/7QTTk06pWgffGOWj5q/L7FzYVuzXYSh6PD+jeLoqnubEcZCzOzkKtJGwy19uzdGo+a9K9hA8ZSGmXLKdzu0ft7CrUKrghFg8nXTsnLqHN3rk0zxR0S00PrBnaHLYYCxVBc7MsUndbpJ2I9+oZIObPgemcPNXse/rp2ODRu0kKqk5rolnEhG9r2pm4KFzASdth4UUS3Fc/M1yUoP+UWxpOaRYVqojiPIFmx4xSQvrI06WkAG8toO3xUAaWLe01eiyEfCLYVSyUQh1r2e/3CQmMS371mI25Xa8ELrOpcSccVKzQ+SSdOfbUWVOs3rLEUgGylRWr99qEUc2ayTFVG8vhY61PxyEERvXGQX/HKnMkrxE3WdLptwHBVMrhrGUJkmolmP1UpCvzSB2Y+Nx40ZM/4wJyBY96Ijzr2yVmcFEyUW29ZF0gAR8UQqYDyZx9z1m7L0wzAu+cSsUz3i6xOUHzIUmkYNc2+9R4dpdKG/tYDAHWeaKqn5tuT7j7Gf7HN/SyI+vybd9/1ocO20Tzt9Ou4VZAfXedYzUhe218nDbGx7OTB7FY0n+Q1tfNt93Ve/bMrQU6ik/LYNxpo0WadZUdsGEBwLML3dPqpboTyseP1N+qOf8nF0gut1OCw60/HoSyBFtfXESMQgQPpwUIrphkpFQKDa9cF9U7HShtVIx/8bMkIVAZV4Z9r7sLDJ3rv16/gn+Vj7Xld/z+oE+jIxwjftpxfPKDDQ4Z21x/cggdjd5pNDqP2mmjmqOqHOeSJirHjgdqjBfF0vJxj9UYuWY4DjndKY3SAnPXHPMnWDXc79ff1v6aNUQ1cuxQ5KWc2oRK+2nc15w2+OXajrbmuicd+pwMxsngY+PhLvEf2TO4eDiD1gcxIeCOT30+K2OOtPOYR9wbJdRePxalRr9b3DV/KGb2Amj5dzFDJZmYEA8+VT4rY871HsU88lkoofYhsSitCkjmiNPuYs0wLhHHEGGnPOWu5srxZzc7/Nts3hbev37CJD6Cv418DRTG+DTCMIVoPsYIS8lWSCjOcIYzkpBkDSd0zDhyCBFGOa8x+DvUw1Kf59azTjgfzxqxRFBCB/Yam4yO4jQcyVbIcRJjSjbW+CIUdQKt34+JQU8sTipMcKcOFCfefELBJYOc1wgpPxz7IFSCKc56xk9PsKB7rz5BidgR6FdD+kGMi26HmBmnIOS2MwSTIkfDkzEgwIAf506wJ+gkqPnD2ikSV0E3nSuc2s41qPLnsN3DcsoshXHGy63Az79zTgTEs2sRKBYRjKGceISwH0ZkVhCHI+Iz/uqJ8xAA80r+f/+TTkAl8FnSpZeoQKAgyU4Fy1KmUICEbqUINSBbua++yKfPQCxDRoyZMBXGnBkLlqzlsmHHlj0HThw5c+HKnRsPnlrl0RT8tWlXHKZlOy63x1tGd5+/kILOYLLYHC6PX5H4npX0KlFSLZZIZXKFUgWAEIygGK7WaHV6g5EwmS1Wm93hdLk9Xk3phmnZjuv5QRjFSZrlRVnVTdv1wzjNy7rtB2vRDrKhuMHyNW9VT3w24+CzqaB/+61ufP2+2WK+UYCK6HXbQrtmqiTwtSgQtP/2AxceljrCto5ZFeHo8WjhGszpcmvVggtGtdc26B4Qihj6B9DEUAUsM6bbpLuQA2kzJ7Y5JHYyeEVFRmST6T/61uYCENAMDq2Ys1c9Tyrfe2vG7qnXvbmZ73w+Moyhn2eB+vbltx9//edP/u5PvD/qAymjpC3x4mUpn1EKWNKtlTfCjx9/omPZH78D8eQVsx36KBvnDctRecbJOUVJoUuV3zwFqdh20JRBtl3IpQaFpmkpm60faP/rgSoC9MMwNdG6SxbVn6ll+1nOZ1dB77N+XyE7p2XrdVSHuo2cvyk1GFaVjlALuJG8AR9NbLsgW0RQcmc2ApzmRR9IkxTgZDJt4i3Tp40C/qTsyD2/yKbdXywRNsB93TvKGVbkvqfi2mpVQcKnAAA=");
+        }
+
+        .cursor {
+            position: absolute;
+            bottom: 4px; /* 光标偏移量 */
+            left: 0;
+            width: 100%; /* 与字符等宽 */
+            height: 2px; /* 光标高 */
+            background-color: var(--color-7);
+            pointer-events: none; /* 禁止选中 */
+            display: inline-block;
+            z-index: 99999;
         }
     </style>
 </head>
@@ -97,286 +119,444 @@ https://github.com/travellings-link/travellings
          *  6 = 黄色       E = 淡黄色
          *  7 = 白色       F = 亮白色
          */
-        const colors = {
-            0x0: "#0c0c0c", 0x1: "#0037da", 0x2: "#13a10e", 0x3: "#3a96dd",
-            0x4: "#c50f1f", 0x5: "#881798", 0x6: "#c19c00", 0x7: "#cccccc",
-            0x8: "#767676", 0x9: "#3b78ff", 0xA: "#16c60c", 0xB: "#61d6d6",
-            0xC: "#e74856", 0xD: "#b4009e", 0xE: "#f9f1a5", 0xF: "#f2f2f2"
-        };
-        const MAIN = document.body.main || document.getElementById("main") || null;
         const prefix = "t_preference_";
         const getSetting = key => localStorage.getItem(prefix + key);
-        var redirectTimer = null;
 
-        class CONHOST {
-            constructor(rows = 25, cols = 80) {
-                this.rows = rows;
-                this.cols = cols;
-                this.screen = [];
-                this.cursor = { row: 0, col: 0 };
-                this.visibleCursor = true;
-                this.blinkInterval = null;
-                this.pause = false;
-
-                this.clearScreen();
-                this.startBlink();
+        /** 控制台主机对象 */
+        class CONSOLE_HOST {
+            /** 实模式下 VGA 颜色表 */ static VGA_COLORS = {
+                0x0: "#0c0c0c", 0x1: "#0037da", 0x2: "#13a10e", 0x3: "#3a96dd",
+                0x4: "#c50f1f", 0x5: "#881798", 0x6: "#c19c00", 0x7: "#cccccc",
+                0x8: "#767676", 0x9: "#3b78ff", 0xA: "#16c60c", 0xB: "#61d6d6",
+                0xC: "#e74856", 0xD: "#b4009e", 0xE: "#f9f1a5", 0xF: "#f2f2f2"
+            };
+            /** 实模式下 VGA 颜色格式化名称表 */ static FORMAT_VGA_COLORS = {
+                black: 0x0, blue: 0x1, green: 0x2, lightGreen: 0x3,
+                red: 0x4, purple: 0x5, yellow: 0x6, grayWhite: 0x7,
+                gray: 0x8, lightBlue: 0x9, lightCyan: 0xA, paleGreen: 0xB,
+                lightRed: 0xC, lightPurple: 0xD, lightYellow: 0xE, brightWhite: 0xF
+            };
+            static MIN = {
+                /** 最小行数 */ ROWS: 0,
+                /** 最小列数 */ COLS: 0
+            }
+            static MAX = {
+                /** 最大行数 */ ROWS: 50,
+                /** 最大列数 */ COLS: 125
+            };
+            static DEFAULT = {
+                /** 默认行数 */ ROWS: 25,
+                /** 默认列数 */ COLS: 80,
+                /** 默认光标颜色 */ CURSOR_COLOR: "grayWhite",
+                /** 默认背景颜色 */ BACKGROUND_COLOR: "black",
+                /** 默认字体颜色 */ FONT_COLOR: "grayWhite",
+                /** 默认光标闪烁间隔 */ CURSOR_BLINK_INTERVAL: 200
             }
 
-            clearScreen() {
-                // 简单的清空屏幕，以及2 维数组初始化
-                for (let r = 0; r < this.rows; r++) {
-                    this.screen[r] = [];
-                    for (let c = 0; c < this.cols; c++) {
-                        this.screen[r][c] = {
-                            char: " ",
-                            foregroundColor: 0x7,
-                            backgroundColor: 0x0
-                        }
-
-                    }
-
+            /**
+             * 构造函数
+             * @param {(string|HTMLElement)} Element 操作对象元素，控制台窗口将在此处显示，初始化时会清空，接受 HTMLElement 或 ID 字符串
+             * @param {number} rows 缓冲区行数
+             * @param {number} cols 缓冲区列数
+             * @param {object} cursorConfig 光标配置
+             */
+            constructor(
+                Element,
+                rows,
+                cols,
+                /** @type {object} 光标配置 */
+                cursorConfig = {
+                    /** @type {string} 光标颜色的背景 */ backgroundColor: CONSOLE_HOST.DEFAULT.BACKGROUND_COLOR,
+                    /** @type {string} 光标颜色前景 */ foregroundColor: CONSOLE_HOST.DEFAULT.FONT_COLOR,
+                    /** @type {number} 光标闪烁间隔 */ blinkInterval: 200,
                 }
-                this.cursor = { row: 0, col: 0 };
+            ) /* ///////////// START ///////////// */ {
+                // 参数合法性检查
+                /** @type {HTMLElement} 操作元素 */ this.container = ((typeof Element === "string") ? document.getElementById(Element) : Element) || null;
+                /** @type {number} 缓冲区行数 */ this.ROWS = (typeof rows === "number" && rows <= CONSOLE_HOST.MAX.ROWS && rows >= 1) ? rows : CONSOLE_HOST.DEFAULT.ROWS;
+                /** @type {number} 缓冲区列数 */ this.COLS = (typeof cols === "number" && cols <= CONSOLE_HOST.MAX.COLS && cols >= 1) ? cols : CONSOLE_HOST.DEFAULT.COLS;
+                /** @type {Array<data: Array<text: string, foregroundColor: number, backgroundColor: number, element: HTMLElement>, element: HTMLElement>}
+                 * 缓冲区单元表 */ this.screenObject = [];
+                /** @type {string} 控制台 ID */ this.ID = newID();
+                /** @type {boolean} 渲染锁 */ this.renderLock = false;
+                if (!this.container) throw new Error("Console host element not found.");
 
-            }
-
-            /**  */
-            render() {
-                let html = "";
-                for (let r = 0; r < this.rows; r++) {
-                    // const element = this.rows[r];
-                    for (let c = 0; c < this.cols; c++) {
-                        const cell = this.screen[r][c];
-                        const foregroundColor = colors[cell.foregroundColor] || colors[0x7];
-                        const backgroundColor = colors[cell.backgroundColor] || colors[0x0];
-                        const isCursor = (r === this.cursor.row && c === this.cursor.col); // 是否为光标所在位置
-                        const char = isCursor ? (this.visibleCursor ? "_" : " ") : cell.char; // 光标是否可见
-                        html += `<span style="color:${foregroundColor};background-color:${backgroundColor}">${char}</span>`;
-                    }
-                    html += "<br />";
-                }
-                MAIN.innerHTML = html;
-            }
-
-            async print(text, foregroundColor, backgroundColor) {
-                for (let i = 0; i < text.length; i++) {
-                    const ch = text[i];
-                    while (this.pause) {
-                        await sleep(100);
-                    }
-                    if (ch === "\n") {
-                        this.cursor.row++;
-                        this.cursor.col = 0;
-                        if (this.cursor.row >= this.rows) {
-                            this.scrollUp();
-                            this.cursor.row = this.rows - 1;
-                        }
-                        continue;
-                    } else {
-                        // 普通字符
-                        if (this.cursor.row < this.rows && this.cursor.col < this.cols) {
-                            this.screen[this.cursor.row][this.cursor.col] = {
-                                char: ch,
-                                foregroundColor: foregroundColor,
-                                backgroundColor: backgroundColor
-                            };
-                            this.cursor.col++;
-
-                            // 超长字符换行
-                            if (this.cursor.col >= this.cols) {
-                                this.cursor.row++;
-                                this.cursor.col = 0;
-                                if (this.cursor.row >= this.rows) {
-                                    this.scrollUp();
-                                    this.cursor.row = this.rows - 1;
+                /** 光标对象 */
+                this.cursor = {
+                    /** 光标配置 */ _: {
+                        /** @type {object} 位置 */ coordinates: {row: 0, col: 0},
+                        /** @type {boolean} 是否不可见 */ NotVisible: true,
+                        /** @type {string} 光标背景颜色 */ backgroundColor: typeof cursorConfig.backgroundColor === "string" ? CONSOLE_HOST.FORMAT_VGA_COLORS[cursorConfig.backgroundColor] : cursorConfig.backgroundColor,
+                        /** @type {string} 光标前景颜色 */ foregroundColor: typeof cursorConfig.foregroundColor === "string" ? CONSOLE_HOST.FORMAT_VGA_COLORS[cursorConfig.foregroundColor] : cursorConfig.foregroundColor,
+                        /** @type {number} 光标控制器周期毫秒数 */ blinkInterval: typeof cursorConfig.blinkInterval === "number" ? cursorConfig.blinkInterval : CONSOLE_HOST.DEFAULT.CURSOR_BLINK_INTERVAL,
+                        /** @type {number} 闪烁定时器指针 */ blinkIntervalPointer: 0,
+                        /** @type {boolean} 闪烁状态 */ blinkState: false,
+                        /** @type {HTMLElement} 光标元素对象 */ HTMLElement: null,
+                    },
+                    blink: {
+                        init: () => {
+                            this.cursor._.HTMLElement = document.createElement("span");
+                            this.cursor._.HTMLElement.className = "cursor";
+                            if (this.cursor._.blinkIntervalPointer !== 0) clearInterval(this.cursor._.blinkIntervalPointer); // 清空遗留的循环器，尽管这个函数不因被重复调用
+                            this.cursor._.blinkIntervalPointer = setInterval(this.cursor.blink.upData, this.cursor._.blinkInterval);
+                        },
+                        /** 改变可见性，控制`NotVisible`
+                         * @param state {boolean} 可见性？*/
+                        setState: (state) => {
+                            this.cursor._.blinkState = state;
+                        },
+                        /** 取到当前状态 */
+                        getState: () => {
+                            return this.cursor._.blinkState
+                        },
+                        /** 更新函数 */
+                        upData: () => {
+                            if (this.cursor._.NotVisible) return; // 如果禁用光标，返回
+                            this.cursor._.blinkState = !this.cursor._.blinkState; // 置状态
+                            const currentParent = this.cursor._.HTMLElement.parentNode; // 获取到现在（实际）的父元素
+                            const el = this.screenObject[this.cursor._.coordinates.row].data[this.cursor._.coordinates.col].element; // 获取到现在光标位置（理论）上的父元素
+                            // 只有在父节点发生变化时才移动 DOM 元素
+                            if (currentParent !== el) {
+                                if (currentParent) {
+                                    currentParent.removeChild(this.cursor._.HTMLElement); // 从旧地移除
                                 }
+                                el.appendChild(this.cursor._.HTMLElement);
                             }
+                            this.cursor._.HTMLElement.style.display = this.cursor._.blinkState ? "block" : "none";
+                            // this.cursor._.oldParentNode = this.cursor._.HTMLElement.parentNode;
+                        }
+                    },
+
+                    /** 光标移动控制 */
+                    move: {
+                        get: () => {
+                            return this.cursor._.coordinates
+                        },
+                        set: (row, col) => {
+                            if (row >= 0 && row < this.ROWS && col >= 0 && col < this.COLS) {
+                                this.cursor._.coordinates.row = row;
+                                this.cursor._.coordinates.col = col;
+                                this.screenObject[row].data[col].element.appendChild(this.cursor._.HTMLElement);
+                                this.cursor._.HTMLElement.style.display = 'block'; // 显示
+                                return true;
+                            } else {
+                                console.error(new RangeError(`欲移动的位置非法：(${row}, ${col}), the MIN is (${CONSOLE_HOST.MIN.COLS}, ${CONSOLE_HOST.MIN.ROWS}), the MAX is (${this.ROWS - 1}, ${this.COLS - 1})`, `Console host cursor move error.`));
+                                return false;
+                            }
+                        },
+
+                        /** 移动到指定位置
+                         * @param {number} row 行号
+                         * @param {number} col 列号
+                         * @return {boolean}
+                         */
+                        moveTo: (row, col) => {
+                            return this.cursor.move.set(row, col);
+                        },
+                        /** 向上移动一位
+                         * @returns {boolean}  */
+                        moveUp: () => {
+                            if (this.cursor._.coordinates.row === 0) return false;
+                            else this.cursor._.coordinates.row--;return true;
+                        },
+                        /** 向下移动一位
+                         * @returns {boolean}  */
+                        moveDown: () => {
+                            if (this.cursor._.coordinates.row >= this.ROWS - 1) return false;
+                            else this.cursor._.coordinates.row++;return true;
+                        },
+                        /** 向左移动一位
+                         * @returns {boolean}  */
+                        moveLeft: () => {
+                            if (this.cursor._.coordinates.col === 0) return false;
+                            else this.cursor._.coordinates.col--;return true;
+                        },
+                        /** 向右移动一位
+                         * @returns {boolean}  */
+                        moveRight: () => {
+                            if (this.cursor._.coordinates.col >= this.COLS - 1) return false;
+                            else this.cursor._.coordinates.col++;return true;
+                        }
+
+                    },
+                    /** 取位置
+                     * @returns {{row: number, col: number}}
+                     */
+                    getPosition: () => ({"row": this.cursor._.coordinates.row, "col": this.cursor._.coordinates.col}),
+
+                    /** 设置光标位置
+                     * @param {number} row 行号
+                     * @param {number} col 列号
+                     */
+                    setPosition: (row, col) => {
+                        this.cursor._.coordinates.row = typeof row === "number" ? row : this.cursor._.coordinates.row;
+                        this.cursor._.coordinates.col = typeof col === "number" ? col : this.cursor._.coordinates.col
+                    },
+
+                    /** 设置可见
+                     * @param {boolean} visible 是否可见
+                     */
+                    setVisible: (visible) => {
+                        this.cursor.blink.setState(true);
+                        this.cursor.blink.upData();
+                        this.cursor._.NotVisible = visible;
+
+                    },
+
+                    /** 设置闪烁间隔
+                     * @param {number} interval 闪烁间隔
+                     */
+                    setBlinkInterval: (interval) => {
+                        this.cursor._.blinkInterval = typeof interval === "number" ? interval : this.cursor._.blinkInterval
+                    },
+                }
+                this.init();
+            } ////////////// END //////////////
+
+            /** 清空 */
+            cls() {
+                for (let i = 0; i < this.ROWS; i++) {
+                    for (let j = 0; j < this.COLS; j++) {
+                        this.printTo(i, j, " ", CONSOLE_HOST.DEFAULT.FONT_COLOR, CONSOLE_HOST.DEFAULT.BACKGROUND_COLOR);
+                    }
+                }
+                this.cursor.move.set(0, 0);
+                this.cursor._.HTMLElement = document.createElement("span");
+                this.cursor._.HTMLElement.className = "cursor";
+                this.printTo(0, 0, " ", CONSOLE_HOST.DEFAULT.FONT_COLOR, CONSOLE_HOST.DEFAULT.BACKGROUND_COLOR);
+            }
+
+            init() {
+                try {
+                    // 初始化显示字符单元表
+                    // 为了减少 DOM 操作，采用 2 维数组存储字符单元，并将其渲染到元素中
+                    // 为了防止每个 span 都要重新绘制页面，采用了双 for，
+                    // 清空容器
+                    this.screenObject = [];
+                    let HTML = "";
+
+                    ////////////// 准备元素 //////////////
+                    for (let i = 0; i < this.ROWS; i++) {
+                        HTML += `<div id="row-${i}" class="row">`;
+                        for (let j = 0; j < this.COLS; j++) {
+                            HTML += `<span id="${i}-${j}" class="cell"> </span>`;
+                        }
+                        HTML += `<br /></div>`;
+                    }
+                    this.container.innerHTML = HTML; // 写入 HTML 元素
+                    /** 所有行 */ const rows = this.container.querySelectorAll(".row");
+                    /** 所有字符单元 */ const cells = this.container.querySelectorAll(".cell");
+
+                    ////////////// 准备索引对象 //////////////
+                    let cellIndex = 0;
+                    const fgc = CONSOLE_HOST.VGA_COLORS[CONSOLE_HOST.FORMAT_VGA_COLORS[CONSOLE_HOST.DEFAULT.FONT_COLOR]];
+                    const bgc = CONSOLE_HOST.VGA_COLORS[CONSOLE_HOST.FORMAT_VGA_COLORS[CONSOLE_HOST.DEFAULT.BACKGROUND_COLOR]];
+                    for (let i = 0; i < this.ROWS; i++) {
+                        const rowElement = rows[i];
+                        this.screenObject[i] = { // 定义一行
+                            data: [],
+                            element: rowElement
+                        };
+                        for (let j = 0; j < this.COLS; j++) {// 将获取到的单元格按宽度排入每行
+                            const cellElement = cells[cellIndex]; // 单元格元素
+                            this.screenObject[i].data[j] = {
+                                text: " ",
+                                foregroundColor: fgc,
+                                backgroundColor: bgc,
+                                element: cellElement
+                            };
+                            cellIndex++;
                         }
                     }
-
+                    this.cursor.blink.init(); // 初始化光标
+                    this.cursor.move.moveTo(0, 0); // 移动光标到初始位置
+                } catch (error) {
+                    throw new Error(`Console host init error: ${error.message}`);
                 }
-                this.render(); // 重新绘制更新位置
+            }
+            /**
+             * 打印文字到控制台
+             * @param {string} text 欲打印的字符串
+             * @param {string|number} foregroundColor 前景颜色
+             * @param {string|number} backgroundColor 背景颜色
+             */
+            print(text, foregroundColor = CONSOLE_HOST.DEFAULT.FONT_COLOR, backgroundColor = CONSOLE_HOST.DEFAULT.BACKGROUND_COLOR) {
+                console.info("PRINT: ", text);
+                this.cursor.setVisible(true); // 置光标控制器
+                this.renderLock = true; // 锁定渲染器
+                const textArray = text.split("");
+                if (foregroundColor === backgroundColor) console.warn(`检测到无效的颜色属性，欲打印的字符前景与后景颜色相同：${foregroundColor}`);
+                for (let i = 0; i < textArray.length; i++) {
+                    const character = (textArray[i] === " ") ? " " : textArray[i];
+                    this.printTo(
+                        this.cursor._.coordinates.row,
+                        this.cursor._.coordinates.col,
+                        character,
+                        foregroundColor,
+                        backgroundColor
+                    );
+                    if (character !== "\n") this.cursor.move.moveRight();
+                }
+                this.renderLock = false;
+                this.renderAll()
+                this.cursor.setVisible(false); // 置光标控制器
+            }
+
+            /**
+             * 打印到
+             * @param {number} row 位置：行
+             * @param {number} col 位置：列
+             * @param {string} text 要打印的字符，只会使用传入字符的第一个
+             * @param {string} foregroundColor 前景色彩
+             * @param {string} backgroundColor 背景色彩
+             * @info 该方法不检查参数合法性，请确保传入的行列号正确
+             * @info 该方法只会使用传入字符的第一个
+             */
+            printTo(row, col, text, foregroundColor = CONSOLE_HOST.DEFAULT.FONT_COLOR, backgroundColor = CONSOLE_HOST.DEFAULT.BACKGROUND_COLOR) {
+                const textArray = text.split("");
+                const character = textArray[0] || " ";
+                const characterElement = this.screenObject[
+                    typeof row === "number" ? row : this.cursor._.coordinates.row].data[ // 此处可能会有语言服务器无法解释的现象，但在浏览器中是按预期运行的
+                    typeof col === "number" ? col : this.cursor._.coordinates.col];
+                // while (this.state.pauseBreak) {
+                //     sleep(100);
+                //     if (this.state.pauseBreak) break;
+                // }
+                switch (character) {
+                    case "\n":
+                        if (this.cursor.move.moveDown() === false) {
+                            this.scrollUp();
+                            this.cursor.move.moveTo(this.ROWS - 1, 0);
+                        } else {
+                            this.cursor.move.moveTo(this.cursor._.coordinates.row, 0);
+                        }
+                        break;
+                    default:
+                        characterElement.text = character;
+                        characterElement.foregroundColor = characterElement.element.style.color = this._toColorCode(foregroundColor);
+                        characterElement.backgroundColor = characterElement.element.style.backgroundColor = this._toColorCode(backgroundColor);
+                        // characterElement.element.innerText = `${character}`;
+                        if (this.cursor._.coordinates.col >= this.COLS) console.warn(`超出列数限制：${this.cursor._.coordinates.col}, the MAX is ${this.COLS - 1}\n超长的将会丢弃。`)
+                        break;
+                }
+                console.debug(`Print to (${row}, ${col}) with ${character} and ${foregroundColor}, ${backgroundColor}`)
             }
 
             scrollUp() {
-                // 移动屏幕内容
-                for (let r = 1; r < this.rows; r++) {
-                    this.screen[r - 1] = [...this.screen[r]];
-                }
-
-                // 清空尾行
-                for (let r = 0; r < this.cols; r++) {
-                    this.screen[this.rows - 1][r] = {
-                        char: " ",
-                        foregroundColor: 0x7,
-                        backgroundColor: 0x0
+                // 向上滚动：将下一行的数据复制到当前行
+                for (let r = 0; r < this.ROWS - 1; r++) {
+                    for (let c = 0; c < this.COLS; c++) {
+                        const currentCell = this.screenObject[r].data[c];
+                        const nextCell = this.screenObject[r + 1].data[c];
+                        currentCell.text = nextCell.text;
+                        currentCell.foregroundColor = nextCell.foregroundColor;
+                        currentCell.backgroundColor = nextCell.backgroundColor;
                     }
                 }
 
+                // 清空最后一行
+                for (let c = 0; c < this.COLS; c++) {
+                    const lastCell = this.screenObject[this.ROWS - 1].data[c];
+                    lastCell.text = " ";
+                    lastCell.foregroundColor = CONSOLE_HOST.VGA_COLORS[CONSOLE_HOST.FORMAT_VGA_COLORS[CONSOLE_HOST.DEFAULT.FONT_COLOR]]; // 灰色
+                    lastCell.backgroundColor = CONSOLE_HOST.VGA_COLORS[CONSOLE_HOST.FORMAT_VGA_COLORS[CONSOLE_HOST.DEFAULT.BACKGROUND_COLOR]]; // 黑色
+                }
+                this.renderAll(); // 刷新整个屏幕
+                // 滚动后，光标移动到最后一行的第一个字符位置
             }
 
-            startBlink() {
-                if (this.blinkInterval) clearInterval(this.blinkInterval);
-                this.blinkInterval = setInterval(() => {
-                    if (getSelectedText() !== "") return;
-                    this.visibleCursor = !this.visibleCursor;
-                    this.render();
-                }, 200);
+            /**
+             * 渲染元素
+             * @param {number} row 行
+             * @param {number} col 列
+             * @param {string} text 要渲染的元素
+             * @param {(string|number)} backgroundColor
+             * @param {(string|number)} foregroundColor
+             */
+            render(row, col, text, backgroundColor = CONSOLE_HOST.DEFAULT.BACKGROUND_COLOR, foregroundColor = CONSOLE_HOST.DEFAULT.FONT_COLOR) {
+                if (this.renderLock) return false;
+                // 重新渲染指定单元格
+                const cell = this.screenObject[row].data[col];
+                cell.element.style.color = typeof foregroundColor === "string" ? foregroundColor : CONSOLE_HOST.VGA_COLORS[foregroundColor];
+                cell.element.style.backgroundColor = typeof backgroundColor === "string" ? backgroundColor : CONSOLE_HOST.VGA_COLORS[backgroundColor];
+                cell.text = text;
+                cell.element.innerText = text;
             }
 
-            stopBlink() {
-                if (this.blinkInterval) clearInterval(this.blinkInterval);
-                this.blinkInterval = null;
-                this.visibleCursor = true;
+            /**
+             * 使用 `screenObject` 的数据，渲染指定的单元格
+             * @param row {number} 行
+             * @param col {number} 列
+             */
+            render_inObject(row ,col) {
+                if (this.renderLock) return false;
+                const cell = this.screenObject[row].data[col];
+                cell.element.style.color = cell.foregroundColor;
+                cell.element.style.backgroundColor = cell.backgroundColor;
+                cell.element.innerText = cell.text;
             }
-        }
 
-        const CONSOLE = new CONHOST(25, 125);
-        const backStart = async function (event) {
-             {
+            /**
+             * 使用 `screenObject` 的数据，渲染指定的单元格
+             * @param data {Array<[row:number, col:number]>} 指定的单元格
+             * @example renderArray_inObject({[row: 0, col: 1], [row: 0, col: 2], ...})
+             */
+            renderArray_inObject(data) {
+                if (this.renderLock) return false;
+                for (let i = 0; i < data.length; i++) {
+                    this.render_inObject(data[i].row, data[i].col);
+                }
+            }
+
+            /** 单次渲染所有单元格 */
+            renderAll() {
+                if (this.renderLock) return false;
+                // 清空容器
+                // 重新渲染整个屏幕
+                for (let i = 0; i < this.ROWS; i++) {
+                    for (let j = 0; j < this.COLS; j++) {
+                        const cell = this.screenObject[i].data[j];
+                        cell.element.style.color = cell.foregroundColor;
+                        cell.element.style.backgroundColor = cell.backgroundColor;
+                        cell.element.innerText = cell.text;
+                    }
+                }
+            }
+
+            renderHTML(row, col, html) {
+                // 重新渲染指定单元格
+                const cell = this.screenObject[row].data[col];
+                cell.element.innerHTML = html;
+            }
+
+            /** 转化颜色为 HTML 颜色代码 */
+            _toColorCode(color) {
                 try {
-                    // 页面从缓存恢复，重新开始
-                    if (redirectTimer) {
-                        clearTimeout(redirectTimer);
-                        redirectTimer = null;
-                    }
-                    CONSOLE.print("\n\n", 0x7, 0x0);
-                    CONSOLE.print(`\n\n ================== Welcome back! ================== \n`, 0x0, 0x7);
-                    CONSOLE.print("\nReady to Travellings...", 0x7, 0x0);
-                    const website = await requestRandomWebsite();
-                    CONSOLE.print(`\nDear Fellow Visitors, the next site is "${website.name}" and the address is "${website.url}". \n`, 0x7, 0x0);
-                
-                    const travellingTimeout = getSetting("timeout") || 1500;
-                    CONSOLE.print(`You have ${travellingTimeout / 1000} seconds to prepare. Good luck!\n`, 0x7, 0x0);
-
-                    redirectTimer = setTimeout(() => {
-                        CONSOLE.print("The shuttle is now departing. Redirecting now...\n", 0x7, 0x0);
-                        window.location.href = website.url;
-                    }, travellingTimeout);
-                } catch (error) {
-                    CONSOLE.print(`\nError: ${error.message}\n`, 0x4, 0x0);
-                    CONSOLE.print("Please press ", 0x7, 0x0);
-                    CONSOLE.print(" ENTER ", 0x0, 0x7)
-                    CONSOLE.print(" to try again, or press ", 0x7, 0x0)
-                    CONSOLE.print(" F5 ", 0x0, 0x7)
-                    CONSOLE.print(" to reload the page.\n", 0x7, 0x0)
-                }
-            }
-        }
-
-        const start = async () => {
-            try {
-                if (redirectTimer) {
-                    clearTimeout(redirectTimer);
-                    redirectTimer = null;
-                }
-                
-                CONSOLE.print(`Travellings Shuttle System (c) Travellings-link Project. All rights      reserved. v.0.1.2.9
-                Made by AdminCmd(https://admincmd.xyz) with love.
-            
-                Loading files...`
-                    , 0x7, 0x0);
-                await sleep(500);
-                // playMUS(2000, 1, "square", 0.5);
-                // CONSOLE.print(``, 0x7, 0x0)
-                CONSOLE.print(`\n\n ================== Welcome to Travellings Shuttle System!       ================== \n`, 0x0, 0x7);
-                CONSOLE.print("\nPress ", 0x2, 0x0);
-                CONSOLE.print(" F1 ", 0x0, 0x7)
-                CONSOLE.print(" to open the Travellings about page.\n", 0x2, 0x0)
-                CONSOLE.print("Press ", 0x2, 0x0)
-                CONSOLE.print(" F2 ", 0x0, 0x7)
-                CONSOLE.print(" to enter the Preferences Settings.\n", 0x2, 0x0)
-                CONSOLE.print("\nIf you would like to add your site to Travellings, \nPress ", 0x2, 0x0)
-                CONSOLE.print(" F3 ", 0x0, 0x7)
-                CONSOLE.print(" or visit https://www.travellings.cn/docs/join.html !\n", 0x2, 0x0);
-    
-                CONSOLE.print("\nReady to Travellings...", 0x7, 0x0);
-                const website = await requestRandomWebsite();
-                CONSOLE.print(`\nDear Fellow Visitors, the next site is "${website.name}" and the address is "${website.url}". \n`, 0x7, 0x0);
-                
-                while (CONSOLE.pause) {
-                    await sleep(100);
-                }
-                const travellingTimeout = getSetting("timeout") || 3500;
-                CONSOLE.print(`You have ${travellingTimeout / 1000} seconds to prepare. Good luck!\n`, 0x7, 0x0);
-                
-                redirectTimer = setTimeout(async () => {
-                    while (CONSOLE.pause) {
-                        await sleep(100);
-                    }
-                    CONSOLE.print("The shuttle is now departing. Redirecting now...\n", 0x7, 0x0);
-
-                    window.location.href = website.url;
-                }, travellingTimeout);
-            } catch (error) {
-                console.error("启动失败:", error);
-                CONSOLE.print(`\nError: ${error.message}\n`, 0x4, 0x0);
-                CONSOLE.print("Please press ", 0x7, 0x0);
-                CONSOLE.print(" ENTER ", 0x0, 0x7)
-                CONSOLE.print(" to try again, or press ", 0x7, 0x0)
-                CONSOLE.print(" F5 ", 0x0, 0x7)
-                CONSOLE.print(" to reload the page.\n", 0x7, 0x0)
-                CONSOLE.print(`Both the main and backup APIs failed. Please visit https://github.com/travellings-link/travellings for more information.\n`, 0x7, 0x0);
-            }
-            
-        }
-        document.addEventListener('keydown', function (event) {
-                // 处理 Ctrl + C（中断）
-                if (event.ctrlKey && event.key === 'c') {
-                    // 如果有选中的文本，让浏览器执行复制（不中断）
-                    if (getSelectedText() !== '') {
-                        return; // 让默认行为发生
-                    } else {
-                        event.preventDefault(); // 阻止复制（因为没选中文本，防止某些浏览器弹出）
-                        if (redirectTimer) {
-                            clearTimeout(redirectTimer);
-                            redirectTimer = null;
-                            // 打印中断信息（模仿终端风格）
-                            CONSOLE.print("^C\n", 0x7, 0x0);
-                            CONSOLE.print("Travelling cancelled.\n", 0xC, 0x0); // 红色/淡红色
-                            CONSOLE.print("Press ", 0x7, 0x0);
-                            CONSOLE.print(" ENTER ", 0x0, 0x7)
-                            CONSOLE.print(" to start a new Travellings trip.\n", 0x7, 0x0);
+                    if (typeof color === "number") {
+                        return CONSOLE_HOST.VGA_COLORS[color] || CONSOLE_HOST.VGA_COLORS[0x7];
+                    } else if (typeof color === "string") {
+                        const textArray = color.split("");
+                        if (textArray[0] === "#") {
+                            return color;
+                            // return parseInt(color.slice(1), 16);
+                        } else {
+                            const code = CONSOLE_HOST.FORMAT_VGA_COLORS[color];
+                            if (code === undefined) {
+                                console.warn(`Unknown color name: ${color}, falling back to grayWhite`);
+                                return CONSOLE_HOST.VGA_COLORS[0x7];
+                            }
+                            return CONSOLE_HOST.VGA_COLORS[code];
                         }
-                        return;
+                    } else {
+                        console.error(new Error(`Invalid color code: ${color}, What is it? Falling back to grayWhite`));
+                        return CONSOLE_HOST.VGA_COLORS[0x7];
                     }
+                } catch (error) {
+                    console.error(new Error(`Invalid color code: ${color}, ${error.message}, falling back to grayWhite`));
+                    return CONSOLE_HOST.VGA_COLORS[0x7];
                 }
-
-            switch (event.key) {
-                case 'F1':
-                    event.preventDefault();
-                    CONSOLE.print("Please later...", 0x7, 0x0);
-                    window.location.href = "https://www.travellings.cn";
-                    break;
-                case 'F2':
-                    event.preventDefault();
-                    CONSOLE.print("Open the preference settings...", 0x7, 0x0);
-                    goSetting();
-                    break;
-                case 'F3':
-                    event.preventDefault();
-                    CONSOLE.print("Please later...")
-                    window.location.href = "https://www.travellings.cn/docs/join.html";
-                    break;
-                case 'Pause':
-                    CONSOLE.pause = !CONSOLE.pause;
-                    break;
-                case 'Enter':
-                    event.preventDefault();
-                    backStart(event);
-                    break;
-                default:
-                    break;
             }
-        });
-
-        window.addEventListener('pageshow', 
-            async function (event) {
-                if (event.persisted) backStart(event);
-            }
-        );
-
-        start();
+        }
 
         /**
          * 休眠线程
@@ -384,20 +564,19 @@ https://github.com/travellings-link/travellings
          * @returns {null} 等他返回了程序不就继续了吗
          */
         function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
-
         /**
          * 取到当前页面的被选中文本
          * @returns { string | null } 当前选中的文本，如果没有选中返回 “”，如果失败则返回 null
          */
         function getSelectedText() {
             if (window.getSelection) {
-                var selection = window.getSelection().toString();
+                const selection = window.getSelection().toString();
                 if (selection === '') {
                     return '';
                 }
                 return selection;
             } else if (document.selection) { // IE < 9
-                var range = document.selection.createRange();
+                const range = document.selection.createRange();
                 if (range.text.trim() === '') {
                     return '';
                 }
@@ -406,76 +585,285 @@ https://github.com/travellings-link/travellings
             return null;
         }
 
-        function goSetting() {window.location.href = "https://www.travellings.cn/preference"; }
-
-        // 辅助函数：转义 HTML 特殊字符
-        function escapeHtml(str) {
-            return str.replace(/[&<>]/g, function (m) {
-                if (m === '&') return '&amp;';
-                if (m === '<') return '&lt;';
-                if (m === '>') return '&gt;';
-                return m;
-            }).replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, function (c) {
-                return c;
+        const CONSOLE = new CONSOLE_HOST(
+            document.getElementById("main"), 25, 125, {
+                "backgroundColor": CONSOLE_HOST.VGA_COLORS[CONSOLE_HOST.FORMAT_VGA_COLORS.black],
+                "foregroundColor": CONSOLE_HOST.VGA_COLORS[CONSOLE_HOST.FORMAT_VGA_COLORS.white]
             });
+
+        // 处理退回页面事件
+        window.addEventListener('pageshow',
+            async function (event) {
+                if (event.persisted) times = 0xFFFF00;
+            }
+        );
+
+        // 处理按键事件
+        document.addEventListener('keydown', function (event) {
+            // 处理 Ctrl + C（中断）
+            if (event.ctrlKey && event.key === 'c') {
+                // 如果有选中的文本，让浏览器执行复制（不中断）
+                if (getSelectedText() !== '') {
+                    return; // 让默认行为发生
+                } else {
+                    event.preventDefault(); // 阻止默认情况
+                    if (currentAbortController) {
+                        currentAbortController.abort();  // 立即中断网络请求
+                        currentAbortController = null;
+                    }
+                    if (times !== 0x1FFFFFE || times !==0x1FFFFFF) times = 0x1FFFFFE; // 置中断运行位置
+                    console.info("Ctrl + C : 操作已执行。")
+                    return;
+                }
+            }
+            switch (event.key) {
+                case 'F1':
+                    event.preventDefault();
+                    CONSOLE.print("Please later...", 0x7, 0x0);
+                    go("https://www.travellings.cn");
+                    break;
+                case 'F2':
+                    event.preventDefault();
+                    CONSOLE.print("Open the preference settings...", 0x7, 0x0);
+                    go("https://www.travellings.cn/preference");
+                    break;
+                case 'F3':
+                    event.preventDefault();
+                    CONSOLE.print("Please later...")
+                    go("https://www.travellings.cn/docs/join.html");
+                    break;
+                case 'Pause':
+                    pauseBreak = !pauseBreak;
+                    clockEvenLock = false;
+                    console.info("PauseBreak: 操作已执行。")
+                    break;
+                case 'Enter':
+                    event.preventDefault();
+                    times = 0xFFFF00; // 置返回位置
+                    // clockEvenLock = false;
+                    console.info("Enter: 操作已执行。")
+                    break;
+                default:
+                    break;
+            }
+        });
+
+        let times = 0; // 计数器
+        let pauseBreak = false; // 暂停回显？
+        let clockEvenLock = false; // 函数锁，阻止某一个周期尚未执行完时就产生新的调用
+        const mainApiUrl = "https://api.travellings.cn/random";
+        const backApiUrl = "https://backup.api.travellings.cn/list.json";
+        let nextWebsite;
+        let timeoutClock = 30; // 等待时间次数
+        let timeoutResidual = 0; // 等待时间的余数，应该小于 {@link clockTimeout}
+        const clockTimeout = 50; // 时钟时间
+        let currentAbortController = null;
+        setInterval(clockEvents, clockTimeout); // 设置一个时钟
+        async function clockEvents() { // 时钟回调事件
+            if (clockEvenLock) return; else clockEvenLock = true; // 阻止重复执行
+            if (pauseBreak) return;
+            switch (times) {
+                case 0: // 程序开始时打印 0×50ms=0ms
+                    CONSOLE.print(
+                        `Travellings Shuttle System (c) Travellings-link Project. All rights reserved. v.0.2.3.9
+Made by AdminCmd(https://admincmd.xyz)#1355 with love.
+
+Loading files...`, 0x7, 0x0);
+                    break;
+                case 10: // 10×50ms=500ms
+                    CONSOLE.print(`\n\n ================== Welcome to Travellings Shuttle System! ================== \n`, 0x0, 0x7);
+                    break;
+                case 11: // 11×50ms=550ms
+                    CONSOLE.print("\nPress ", 0x2, 0x0);
+                    CONSOLE.print(" F1 ", 0x0, 0x7)
+                    CONSOLE.print(" to open the Travellings about page.\n", 0x2, 0x0)
+                    CONSOLE.print("Press ", 0x2, 0x0)
+                    CONSOLE.print(" F2 ", 0x0, 0x7)
+                    CONSOLE.print(" to enter the Preferences Settings.\n", 0x2, 0x0)
+                    CONSOLE.print("\nIf you would like to add your site to Travellings, \nPress ", 0x2, 0x0)
+                    CONSOLE.print(" F3 ", 0x0, 0x7)
+                    CONSOLE.print(" or visit https://www.travellings.cn/docs/join.html !\n", 0x2, 0x0);
+                    break;
+                case 12: // 10×50ms=600ms
+                    CONSOLE.print("\nReady to Travellings...", 0x7, 0x0);
+                    nextWebsite = await getMainApi();
+                    break;
+                case 13: { //
+                    CONSOLE.print(`\nDear Fellow Visitors, the next site is "${nextWebsite.name}" and the address is "${nextWebsite.url}". \n`, 0x7, 0x0);
+                    const travellingTimeout = getSetting("timeout") || 1500;
+                    timeoutClock = travellingTimeout / clockTimeout; // 计算应该等待多少个周期
+                    timeoutResidual = travellingTimeout % clockTimeout; // 计算应该在最后一个周期等多长时间以满足用户配置
+                    CONSOLE.print(`You have ${travellingTimeout / 1000} seconds to prepare. Good luck!\n`, 0x7, 0x0);
+                    break;
+                }
+                case 13 + timeoutClock: {
+                    await sleep(timeoutResidual);
+                    await go(nextWebsite.url);
+                    break;
+                }
+                // 这后面就是页面返回时候运行的了
+                case 0xFFFF00: {
+                    CONSOLE.print("\n\n", 0x7, 0x0);
+                    CONSOLE.print(` ================== Welcome back! ================== \n`, 0x0, 0x7);
+                    CONSOLE.print("\nReady to Travellings...", 0x7, 0x0);
+                    nextWebsite = await getMainApi();
+                    CONSOLE.print(`\nDear Fellow Visitors, the next site is "${nextWebsite.name}" and the address is "${nextWebsite.url}". \n`, 0x7, 0x0);
+                    const travellingTimeout = getSetting("timeout") || 1500;
+                    timeoutClock = travellingTimeout / clockTimeout;
+                    timeoutResidual = travellingTimeout % clockTimeout;
+                    CONSOLE.print(`You have ${travellingTimeout / 1000} seconds to prepare. Good luck!\n`, 0x7, 0x0);
+                    break;
+                }
+                case 0xFFFF00 + timeoutClock: {
+                    await sleep(timeoutResidual);
+                    go(nextWebsite.url);
+                    break;
+                }
+                case 0x1FFFFFE: { // Ctrl + C 中断
+                    CONSOLE.print("^C\n", 0x7, 0x0);
+                    CONSOLE.print("Travelling cancelled.\n", 0xC, 0x0); // 红色/淡红色
+                    CONSOLE.print("Press ", 0x7, 0x0);
+                    CONSOLE.print(" ENTER ", 0x0, 0x7)
+                    CONSOLE.print(" to start a new Travellings trip.\n", 0x7, 0x0);
+                    break;
+                }
+                case 0x1FFFFFF:
+                    times = 0x1FFFFFE;// 这样就会卡在这，到下面就 === 0x1FFFFFF
+                    break;
+            }
+            clockEvenLock = false;
+            times++;
         }
-        // 请求随机网站,从另一个页面Ctrl + V 来的
-        async function requestRandomWebsite() {
+
+        async function getMainApi() {
             try {
-                // 获取偏好设置
+                const controller = new AbortController();
+                currentAbortController = controller;
                 const prefix = "t_preference_";
                 const getSetting = key => localStorage.getItem(prefix + key);
                 const preferredTag = getSetting("tag");
-
                 // 尝试主API
-                let apiUrl = "https://api.travellings.cn/random";
-                if (preferredTag) apiUrl += "?tag=" + preferredTag;
-
-                const response = await fetch(apiUrl);
+                const responseUrl = preferredTag ? mainApiUrl + "?tag=" + preferredTag : mainApiUrl;
+                CONSOLE.print(`\n[   ] GET ${responseUrl} ...`);
+                const response = await fetch(responseUrl, { signal: controller.signal });
                 const data = await response.json();
-
                 if (data.success) {
+                    CONSOLE.print("...OK!", 0xa);
                     return {
                         name: data.data[0].name.trim(),
                         url: data.data[0].url.trim()
                     };
                 } else {
+                    CONSOLE.print("...Error!", 0x4);
                     CONSOLE.print("Error: An error occurred in the Travellings API.\n", 0x7, 0x4);
-                    throw new Error("API返回失败");
+                    console.error("主 API 请求失败，返回内容：", data, "\n\n 请求内容", response);
                 }
             } catch (error) {
-                console.error("获取网站失败:", error);
-                CONSOLE.print(`\nError: ${error.message}\n`, 0x4, 0x0);
-                CONSOLE.print(`There was a problem with the Travellings service and an alternate solution was used.\n`, 0x4, 0x0);
+                if (error.name === 'AbortError') {
+                    console.log('请求已被用户取消');
+                    CONSOLE.print("^C")
+                    CONSOLE.print("Travelling cancelled.\n", 0xC, 0x0); // 红色/淡红色
+                    CONSOLE.print("Press ", 0x7, 0x0);
+                    CONSOLE.print(" ENTER ", 0x0, 0x7)
+                    CONSOLE.print(" to start a new Travellings trip.\n", 0x7, 0x0);
+                } else {
+                    CONSOLE.print("...Error!\n", 0x4);
+                    CONSOLE.print(error.toString(), 0x4, 0x0);
+                    CONSOLE.print("\nError: An error occurred in the Travellings API.\n", 0x4, 0x0);
+                    console.error("主 API 请求失败，Error:", error);
+                    currentAbortController = null;
+                    return getBackApi(); // 去请求备用 API
+                }
+            } finally {
 
-                // 使用备份API
+            }
+            currentAbortController = null;
+            clockEvenLock = false;
+        }
+
+        async function getBackApi() {
+            return await getJson();
+
+            async function getJson() {
                 try {
-                    return await getJson();
-                    async function getJson() {
-                        const backupResponse = await fetch("https://backup.api.travellings.cn/list.json");
-                        const backupData = await backupResponse.json();
-                        const list = backupData.data;
-                        const randomIndex = Math.floor(Math.random() * list.length);
-
-                        if (list[randomIndex].status !== "RUN") getJson();// 检查状态
-
-                        return {
-                            name: list[randomIndex].name.trim(),
-                            url: list[randomIndex].url.trim()
-                        };
+                    const controller = new AbortController();
+                    currentAbortController = controller;
+                    CONSOLE.print(`\n[   ] GET ${backApiUrl} ...`)
+                    const backupResponse = await fetch(backApiUrl, { signal: controller.signal });
+                    const backupData = await backupResponse.json();
+                    const list = backupData.data;
+                    CONSOLE.print("...OK!", 0xa);
+                    let randomIndex = 0;
+                    for (let i = 0; i < 100; i++) {
+                        CONSOLE.print(".")
+                        randomIndex = Math.floor(Math.random() * list.length);
+                        if (list[randomIndex].status !== "RUN") continue;// 检查状态
+                        else if (list[randomIndex].status === "RUN") break;
+                        if (i === 100) {
+                            for (let j = 0; j < list.length; j++) {
+                                if (list[j].status === "RUN") {
+                                    randomIndex = j;
+                                    CONSOLE.print(".")
+                                    break;
+                                } // 要是真的一个 RUN 的都没有，那这个页面的服务器大概也不在了。
+                            }
+                        }
                     }
-                } catch (backupError) {
-                    console.error("备份API也失败:", backupError);
-                    // CONSOLE.print(`\nError: ${backupError.message}\n`, 0xF, 0x4);
-                    // CONSOLE.print(`\nBoth the main and backup APIs failed. Please visit https://github.com/travellings-link/travellings for more information.`, 0x7, 0x0);
-                    // CONSOLE.print(`\nPress `, 0x7, 0x0)
-                    // CONSOLE.print(" F5 ", 0x0, 0x7)
-                    // CONSOLE.print(" to reload the page and try again.\n", 0x7, 0x0)
-                    throw new Error("所有API请求失败");
+                    return {
+                        name: list[randomIndex].name.trim(),
+                        url: list[randomIndex].url.trim()
+                    };
+                } catch (Error) {
+                    console.error("备份API也失败:", Error);
+                    if (Error.name === 'AbortError') {
+                        console.log('请求已被用户取消');
+                        CONSOLE.print("^C")
+                        CONSOLE.print("Travelling cancelled.\n", 0xC, 0x0); // 红色/淡红色
+                        CONSOLE.print("Press ", 0x7, 0x0);
+                        CONSOLE.print(" ENTER ", 0x0, 0x7)
+                        CONSOLE.print(" to start a new Travellings trip.\n", 0x7, 0x0);
+                    } else {
+                        CONSOLE.print(`\nError: ${Error.message}\n`, 0xF, 0x4);
+                        CONSOLE.print(`\nBoth the main and backup APIs failed. Please visit https://github.com/travellings-link/travellings for more information.`, 0x7, 0x0);
+                        CONSOLE.print(`\nPress `, 0x7, 0x0)
+                        CONSOLE.print(" F5 ", 0x0, 0x7)
+                        CONSOLE.print(" to reload the page and try again.\n", 0x7, 0x0)
+                        throw new Error("备份API也失败:", Error);
+                    }
+                } finally {
+                    currentAbortController = null;
+                    clockEvenLock = false;
                 }
             }
         }
 
+        function go(url ,enable) {
+            if (isLocalhost(window.location.hostname && !enable)) {
+                console.info("由于以下原因，跳转被阻止：本地调试");
+                return;
+            }
+            window.location.assign(url);
+
+            function isLocalhost(hostname) {
+                // 常见回环地址
+                if (['localhost', '::1', '127.0.0.1'].includes(hostname)) return true;
+                // 匹配 127.0.0.0/8
+                if (/^127\.\d+\.\d+\.\d+$/.test(hostname)) return true;
+                // 匹配 IPv6 回环
+                if (/^::1$/.test(hostname) || /^0:0:0:0:0:0:0:1$/.test(hostname)) return true;
+                return false;
+            }
+        }
+
+        function newID() {
+            try {
+                return crypto.randomUUID();
+            } catch {
+                return Date.now().toString(36)
+                    + Math.random().toString(36).slice(2, 10)
+                    + performance.now().toString(36).replace('.', '');
+            }
+        }
     </script>
 </body>
 

--- a/public/go-start.html
+++ b/public/go-start.html
@@ -837,8 +837,8 @@ Loading files...`, 0x7, 0x0);
             }
         }
 
-        function go(url ,enable) {
-            if (isLocalhost(window.location.hostname && !enable)) {
+        function go(url) {
+            if (isLocalhost(window.location.hostname)) {
                 console.info("由于以下原因，跳转被阻止：本地调试");
                 return;
             }


### PR DESCRIPTION
*本次 PR 主要内容如下：*

*概述*
- 对开往跳转页面 Travellings Shuttle System (.\go-start.html) 的重构和优化
- 对开往跳转页面 Travellings Shuttle System (.\go-start.html) 的日后计划

### 对开往跳转页面 Travellings Shuttle System (.\go-start.html) 的重构和优化
新增内容：
- 现在会在请求 API 时打印请求 API 的信息了；
- 现在可以在请求 API 时按 Ctrl + C 中断请求了；

优化内容 / BUG 修复：
- 重写了控制台控制类，优化了性能（CPU 占用由以前的 25% 下降至 4%，取闲置状态，Firefox 155.0a1 E3-1225）；
- 重写了光标控制，现在的光标不再是字符控制。不再每次光标刷新都需要对整个页面的 DOM 进行操作了；
- 重写了控制流设计，这使得在 API 请求外的任何位置都可以使用 PauseBreak 和 Ctrl + C 了；
- 现在会给每一行的字符单元分配行 div 了；
- 现在使用备份 API 时如果遇到非正常站点不会重复请求了；
- 封装了旧有的 API 请求代码；
- 调小了字体，以便使用小字号宋体的点阵样式，同时使显示更清晰了；
- 修复了按多次 Enter 可以打开多个实例的 bug；

其他内容:
- 提升了版本号；
- 一定的 JSDoc 支持；
- 由于重构，总体积来到了 50.4KiB；
- 在页面中添加了 BUG 反馈的信息；
- 移除了 Herobrine（doge，狗头）；

*以下为非本次 PR 内容。*
### 对开往跳转页面 Travellings Shuttle System (.\go-start.html) 的日后计划
预计日后实现 / 已知 BUG：
- [ ] 提前进行请求以减少加载开往成员站点页面的时间；
- [ ] 在 API 请求的时候可以使用 PauseBreak 暂停回显；
- [ ] 使用更为具体的渲染程序以进一步减少开销；
